### PR TITLE
Add localized domain for wowhead queries  (!lookupItem command)

### DIFF
--- a/lookupCommands/src/main/java/com/greatmancode/legendarybot/plugin/lookupcommands/commands/LookupItemCommand.java
+++ b/lookupCommands/src/main/java/com/greatmancode/legendarybot/plugin/lookupcommands/commands/LookupItemCommand.java
@@ -66,7 +66,47 @@ public class LookupItemCommand implements PublicCommand {
                 JSONObject obj = (JSONObject) jsonParser.parse(EntityUtils.toString(response.getEntity()));
                 JSONArray hit = (JSONArray) ((JSONObject)obj.get("hits")).get("hits");
                 JSONObject firstItem = (JSONObject) hit.get(0);
-                event.getChannel().sendMessage("http://www.wowhead.com/item=" + firstItem.get("_id")).queue();
+                
+                String whLocatedDomain = "www";
+                switch(plugin.getBot().getTranslateManager().getLanguages())
+                {
+                    case "fr":
+                        whLocatedDomain = "fr";
+                        break;
+                        
+                    case "ru":
+                        whLocatedDomain = "ru";
+                        break;
+                        
+                    case "it":
+                        whLocatedDomain = "it";
+                        break;
+                        
+                    case "de":
+                        whLocatedDomain = "de";
+                        break;
+                        
+                    case "es":
+                        whLocatedDomain = "es";
+                        break;
+                        
+                    case "pt":
+                        whLocatedDomain = "pt";
+                        break;
+                        
+                    case "ko":
+                        whLocatedDomain = "ko";
+                        break;
+                        
+                    case "cn":
+                        whLocatedDomain = "cn";
+                        break;
+                        
+                    default:
+                        whLocatedDomain = "www";
+                        break;
+                }
+                event.getChannel().sendMessage("http://" + whLocatedDomain + ".wowhead.com/item=" + firstItem.get("_id")).queue();
             } catch (ParseException e) {
                 e.printStackTrace();
                 event.getChannel().sendMessage(plugin.getBot().getTranslateManager().translate(event.getGuild(), "command.lookupitem.notfound")).queue();


### PR DESCRIPTION
I haven't touch java for a while, but here is my contribution.

If we change the subdomain used, we can retrieve localized informations about those drops